### PR TITLE
Use IGRAB-compatible names for graphics chunks

### DIFF
--- a/SRC/BM_ACT1.C
+++ b/SRC/BM_ACT1.C
@@ -48,12 +48,12 @@ void R_DrMangleJumping();
 
 
 statetype far s_platform = { /* 32250 */
-  PLATFORMSPR, PLATFORMSPR,
+  PLATFORM_SPR, PLATFORM_SPR,
   think, false, ps_none, 0, 0, 0,
   T_Platform, NULL, R_Draw, NULL};
 
 statetype far s_apogeelogo = { /* 32270 */
-  APOGEELOGOSPR, APOGEELOGOSPR,
+  APOGEELOGO_SPR, APOGEELOGO_SPR,
   think, false, ps_none, 0, 0, 0,
   T_Platform, NULL, R_Draw, NULL};
 

--- a/SRC/BM_ACT2.C
+++ b/SRC/BM_ACT2.C
@@ -293,47 +293,47 @@ statetype far s_brawler_attack2 = { /* 32d50 */
   NULL, NULL, R_Draw, &s_brawler_walk1};
 
 statetype far s_ceilwalker_walkceil1 = { /* 32d70 */
-  CEILWALKER_WALK_CEIL1_L, CEILWALKER_WALK_CEIL1_R,
+  CEILWALKER_WALK_CEIL1_L_SPR, CEILWALKER_WALK_CEIL1_R_SPR,
   step, false, ps_toceiling, 10, 128, 0,
   T_CeilingWalkerOnCeiling, NULL, R_WalkCeiling, &s_ceilwalker_walkceil2};
 
 statetype far s_ceilwalker_walkceil2 = { /* 32d90 */
-  CEILWALKER_WALK_CEIL2_L, CEILWALKER_WALK_CEIL2_R,
+  CEILWALKER_WALK_CEIL2_L_SPR, CEILWALKER_WALK_CEIL2_R_SPR,
   step, false, ps_toceiling, 10, 128, 0,
   T_CeilingWalkerOnCeiling, NULL, R_WalkCeiling, &s_ceilwalker_walkceil3};
 
 statetype far s_ceilwalker_walkceil3 = { /* 32db0 */
-  CEILWALKER_WALK_CEIL3_L, CEILWALKER_WALK_CEIL3_R,
+  CEILWALKER_WALK_CEIL3_L_SPR, CEILWALKER_WALK_CEIL3_R_SPR,
   step, false, ps_toceiling, 10, 128, 0,
   T_CeilingWalkerOnCeiling, NULL, R_WalkCeiling, &s_ceilwalker_walkceil4};
 
 statetype far s_ceilwalker_walkceil4 = { /* 32dd0 */
-  CEILWALKER_WALK_CEIL4_L, CEILWALKER_WALK_CEIL4_R,
+  CEILWALKER_WALK_CEIL4_L_SPR, CEILWALKER_WALK_CEIL4_R_SPR,
   step, false, ps_toceiling, 10, 128, 0,
   T_CeilingWalkerOnCeiling, NULL, R_WalkCeiling, &s_ceilwalker_walkceil1};
 
 statetype far s_ceilwalker_walkfloor1 = { /* 32df0 */
-  CEILWALKER_WALK1_L, CEILWALKER_WALK1_R,
+  CEILWALKER_WALK1_L_SPR, CEILWALKER_WALK1_R_SPR,
   step, false, ps_tofloor, 6, 128, 0,
   T_CeilingWalkerOnFloor, NULL, R_Walk, &s_ceilwalker_walkfloor2};
 
 statetype far s_ceilwalker_walkfloor2 = { /* 32e10 */
-  CEILWALKER_WALK2_L, CEILWALKER_WALK2_R,
+  CEILWALKER_WALK2_L_SPR, CEILWALKER_WALK2_R_SPR,
   step, false, ps_tofloor, 6, 128, 0,
   T_CeilingWalkerOnFloor, NULL, R_Walk, &s_ceilwalker_walkfloor3};
 
 statetype far s_ceilwalker_walkfloor3 = { /* 32e30 */
-  CEILWALKER_WALK3_L, CEILWALKER_WALK3_R,
+  CEILWALKER_WALK3_L_SPR, CEILWALKER_WALK3_R_SPR,
   step, false, ps_tofloor, 6, 128, 0,
   T_CeilingWalkerOnFloor, NULL, R_Walk, &s_ceilwalker_walkfloor4};
 
 statetype far s_ceilwalker_walkfloor4 = { /* 32e50 */
-  CEILWALKER_WALK4_L, CEILWALKER_WALK4_R,
+  CEILWALKER_WALK4_L_SPR, CEILWALKER_WALK4_R_SPR,
   step, false, ps_tofloor, 6, 128, 0,
   T_CeilingWalkerOnFloor, NULL, R_Walk, &s_ceilwalker_walkfloor1};
 
 statetype far s_ceilwalker_falling = { /* 32e70 */
-  CEILWALKER_FALL_L, CEILWALKER_FALL_R,
+  CEILWALKER_FALL_L_SPR, CEILWALKER_FALL_R_SPR,
   think, false, ps_none, 0, 0, 0,
   T_Projectile, NULL, R_CeilingWalkerFalling, &s_ceilwalker_falling};
 

--- a/SRC/BM_ACT3.C
+++ b/SRC/BM_ACT3.C
@@ -207,32 +207,32 @@ statetype far s_drmangleshot2 = { /* 33250 */
   T_Velocity, C_EnemyLaserShot, R_EnemyLaserShot, &s_drmangleshot1};
 
 statetype far s_pushblock = { /* 33270 */
-  PUSHBLOCKSPR, PUSHBLOCKSPR,
+  PUSHBLOCK_SPR, PUSHBLOCK_SPR,
   stepthink, false, ps_tofloor, 6, 0, 1,
   NULL, C_PushBlock, R_PushBlock_OnGround, &s_pushblock};
 
 statetype far s_pushblock_falling = { /* 33290 */
-  PUSHBLOCKSPR, PUSHBLOCKSPR,
+  PUSHBLOCK_SPR, PUSHBLOCK_SPR,
   stepthink, false, ps_none, 0, 0, 0,
   T_Projectile, C_PushBlock, R_PushBlock_Falling, &s_pushblock};
 
 statetype far s_fallingblock_idle = { /* 332b0 */
-  FALLINGBLOCKSPR, FALLINGBLOCKSPR,
+  FALLINGBLOCK_SPR, FALLINGBLOCK_SPR,
   stepthink, false, ps_none, 1, 0, 0,
   T_FallingBlock, C_FallingBlock, R_Draw, &s_fallingblock_idle};
 
 statetype far s_fallingblock_falling = { /* 332d0 */
-  FALLINGBLOCKSPR, FALLINGBLOCKSPR,
+  FALLINGBLOCK_SPR, FALLINGBLOCK_SPR,
   stepthink, false, ps_none, 0, 0, 0,
   T_Projectile, NULL, R_FallingBlock, &s_fallingblock_falling};
 
 statetype far s_crusher_idle = { /* 332f0 */
-  CRUSHERBLOCKSPR, CRUSHERBLOCKSPR,
+  CRUSHERBLOCK_SPR, CRUSHERBLOCK_SPR,
   stepthink, false, ps_none, 6, 0, 0,
   T_Crusher_Waiting, NULL, R_Draw, &s_crusher_idle};
 
 statetype far s_crusher_moving = { /* 33310 */
-  CRUSHERBLOCKSPR, CRUSHERBLOCKSPR,
+  CRUSHERBLOCK_SPR, CRUSHERBLOCK_SPR,
   stepthink, false, ps_none, 5, 0, 8,
   T_Crusher_Moving, C_Crusher, R_Crusher, &s_crusher_moving};
 

--- a/SRC/BM_DEMO.C
+++ b/SRC/BM_DEMO.C
@@ -89,11 +89,11 @@ void ShowTitle(Uint16 timeout)
   panadjust = 0;
 
 #ifdef SHAREWARE
-  CA_CacheGrChunk(TITLESHAREWAREPIC);
-  VWB_DrawPic(0, 0, TITLESHAREWAREPIC);
+  CA_CacheGrChunk(TITLESHAREWARE_PIC);
+  VWB_DrawPic(0, 0, TITLESHAREWARE_PIC);
 #else
-  CA_CacheGrChunk(TITLEPIC);
-  VWB_DrawPic(0, 0, TITLEPIC);
+  CA_CacheGrChunk(TITLE_PIC);
+  VWB_DrawPic(0, 0, TITLE_PIC);
 #endif
 
   VW_SetScreen(displayofs, 0);
@@ -125,23 +125,23 @@ void ShowScreen(Sint16 num)
 
   if (num == 0)
   {
-    CA_CacheGrChunk(PREVIEWPIC);
-    VWB_DrawPic(0, 0, PREVIEWPIC);
+    CA_CacheGrChunk(PREVIEW_PIC);
+    VWB_DrawPic(0, 0, PREVIEW_PIC);
   }
   else if (num == 1)
   {
-    CA_CacheGrChunk(CREDITSPIC);
-    VWB_DrawPic(0, 0, CREDITSPIC);
+    CA_CacheGrChunk(CREDITS_PIC);
+    VWB_DrawPic(0, 0, CREDITS_PIC);
   }
   else if (num == 2)
   {
-    CA_CacheGrChunk(NOTSHAREWAREPIC);
-    VWB_DrawPic(0, 0, NOTSHAREWAREPIC);
+    CA_CacheGrChunk(NOTSHAREWARE_PIC);
+    VWB_DrawPic(0, 0, NOTSHAREWARE_PIC);
   }
   else if (num == 3)
   {
-    CA_CacheGrChunk(TECHHELPPIC);
-    VWB_DrawPic(0, 0, TECHHELPPIC);
+    CA_CacheGrChunk(TECHHELP_PIC);
+    VWB_DrawPic(0, 0, TECHHELP_PIC);
   }
 
   VW_SetScreen(displayofs, 0);

--- a/SRC/BM_PLAY2.C
+++ b/SRC/BM_PLAY2.C
@@ -946,8 +946,8 @@ void ShiftScore (void)
   spritetabletype far *spr;
   spritetype _seg *dest;
 
-  spr = &spritetable[SCOREBOXSPR-STARTSPRITES];
-  dest = (spritetype _seg *)grsegs[SCOREBOXSPR];
+  spr = &spritetable[SCOREBOX_SPR-STARTSPRITES];
+  dest = (spritetype _seg *)grsegs[SCOREBOX_SPR];
 
   CAL_ShiftSprite (FP_SEG(dest),dest->sourceoffset[0],
     dest->sourceoffset[1],spr->width,spr->height,2);
@@ -992,10 +992,10 @@ void UpdateScoreBox(objtype *ob)
     (Uint16)gamestate.score != ob->temp2 ||
     practicetimer > 0)
   {
-    block = (spritetype _seg *)grsegs[SCOREBOXSPR];
+    block = (spritetype _seg *)grsegs[SCOREBOX_SPR];
     width = block->width[0];
     planesize = block->planesize[0];
-    dest = (Uint8 far*)grsegs[SCOREBOXSPR] + block->sourceoffset[0] +
+    dest = (Uint8 far*)grsegs[SCOREBOX_SPR] + block->sourceoffset[0] +
       planesize + width*4;
 
     if (practicetimer > 0)
@@ -1020,7 +1020,7 @@ void UpdateScoreBox(objtype *ob)
     // draw "TIME LEFT" label
     if (practicetimer > 0)
     {
-      dest = (Uint8 far*)grsegs[SCOREBOXSPR] + block->sourceoffset[0] +
+      dest = (Uint8 far*)grsegs[SCOREBOX_SPR] + block->sourceoffset[0] +
         planesize + width*4 + CHARWIDTH;
       dest -= CHARWIDTH;
 
@@ -1044,10 +1044,10 @@ void UpdateScoreBox(objtype *ob)
     if (number > 8)
       number = 8;
 
-    block = (spritetype _seg *)grsegs[SCOREBOXSPR];
+    block = (spritetype _seg *)grsegs[SCOREBOX_SPR];
     width = block->width[0];
     planesize = block->planesize[0];
-    dest2 = dest = (Uint8 far*)grsegs[SCOREBOXSPR] + block->sourceoffset[0] +
+    dest2 = dest = (Uint8 far*)grsegs[SCOREBOX_SPR] + block->sourceoffset[0] +
       planesize + width*4 + 8*CHARWIDTH;
 
     for (i=4; i > 0; i--)
@@ -1091,10 +1091,10 @@ void UpdateScoreBox(objtype *ob)
     number = gamestate.explosives.grenades;
   if (number != ob->temp3)
   {
-    block = (spritetype _seg *)grsegs[SCOREBOXSPR];
+    block = (spritetype _seg *)grsegs[SCOREBOX_SPR];
     width = block->width[0];
     planesize = block->planesize[0];
-    dest = (Uint8 far*)grsegs[SCOREBOXSPR] + block->sourceoffset[0] +
+    dest = (Uint8 far*)grsegs[SCOREBOX_SPR] + block->sourceoffset[0] +
       + planesize + width*20 + 4*CHARWIDTH;
 
     if (gamestate.explosives.landmines > 0)
@@ -1120,10 +1120,10 @@ void UpdateScoreBox(objtype *ob)
     number = gamestate.explosives.grenades;
   if (number != ob->temp3)
   {
-    block = (spritetype _seg *)grsegs[SCOREBOXSPR];
+    block = (spritetype _seg *)grsegs[SCOREBOX_SPR];
     width = block->width[0];
     planesize = block->planesize[0];
-    dest = (Uint8 far*)grsegs[SCOREBOXSPR] + block->sourceoffset[0] +
+    dest = (Uint8 far*)grsegs[SCOREBOX_SPR] + block->sourceoffset[0] +
       + planesize + width*20 + 5*CHARWIDTH;
 
     if (number > 99)
@@ -1159,10 +1159,10 @@ void UpdateScoreBox(objtype *ob)
   //
   if (gamestate.ammotype != ob->temp7)
   {
-    block = (spritetype _seg *)grsegs[SCOREBOXSPR];
+    block = (spritetype _seg *)grsegs[SCOREBOX_SPR];
     width = block->width[0];
     planesize = block->planesize[0];
-    dest = (Uint8 far*)grsegs[SCOREBOXSPR] + block->sourceoffset[0] +
+    dest = (Uint8 far*)grsegs[SCOREBOX_SPR] + block->sourceoffset[0] +
       + planesize + width*20 + 9*CHARWIDTH;
 
     if (gamestate.ammotype == AMMO_REGULAR)
@@ -1190,10 +1190,10 @@ void UpdateScoreBox(objtype *ob)
 
   if (number != ob->temp5)
   {
-    block = (spritetype _seg *)grsegs[SCOREBOXSPR];
+    block = (spritetype _seg *)grsegs[SCOREBOX_SPR];
     width = block->width[0];
     planesize = block->planesize[0];
-    dest = (Uint8 far*)grsegs[SCOREBOXSPR] + block->sourceoffset[0] +
+    dest = (Uint8 far*)grsegs[SCOREBOX_SPR] + block->sourceoffset[0] +
       + planesize + width*20 + 10*CHARWIDTH;
 
     if (number > 99)
@@ -1240,10 +1240,10 @@ void UpdateScoreBox(objtype *ob)
   //
   if (gamestate.lives != ob->temp4)
   {
-    block = (spritetype _seg *)grsegs[SCOREBOXSPR];
+    block = (spritetype _seg *)grsegs[SCOREBOX_SPR];
     width = block->width[0];
     planesize = block->planesize[0];
-    dest = (Uint8 far*)grsegs[SCOREBOXSPR] + block->sourceoffset[0] +
+    dest = (Uint8 far*)grsegs[SCOREBOX_SPR] + block->sourceoffset[0] +
       + planesize + width*20 + 2*CHARWIDTH;
 
     if (gamestate.lives > 9)
@@ -1279,10 +1279,10 @@ void UpdateScoreBox(objtype *ob)
       if (number <= 0)
         number = 1;
 
-      block = (spritetype _seg *)grsegs[SCOREBOXSPR];
+      block = (spritetype _seg *)grsegs[SCOREBOX_SPR];
       width = block->width[0];
       planesize = block->planesize[0];
-      dest2 = dest = (Uint8 far*)grsegs[SCOREBOXSPR] + block->sourceoffset[0] +
+      dest2 = dest = (Uint8 far*)grsegs[SCOREBOX_SPR] + block->sourceoffset[0] +
         + planesize + width*32 - 1*CHARWIDTH;
       dest2 += 3*CHARWIDTH;
 
@@ -1355,7 +1355,7 @@ void UpdateScoreBox(objtype *ob)
        &ob->sprite,
        ob->x + 4*PIXGLOBAL,
        ob->y + 4*PIXGLOBAL,
-       SCOREBOXSPR,
+       SCOREBOX_SPR,
        spritedraw,
        3);
   }

--- a/SRC/BM_SPEC.C
+++ b/SRC/BM_SPEC.C
@@ -710,7 +710,7 @@ void ScanInfoPlane(void)
   }
 
 
-  CA_MarkGrChunk(SCOREBOXSPR);
+  CA_MarkGrChunk(SCOREBOX_SPR);
   SpawnScoreBox();
 
   for (i = 0; i < NUMLUMPS; i++)
@@ -750,10 +750,10 @@ void HostageDialog(void)
   }
 
   CA_UpLevel();
-  CA_MarkGrChunk(HOSTAGE1PIC);
-  CA_MarkGrChunk(HOSTAGE2PIC);
-  CA_MarkGrChunk(HOSTAGE3PIC);
-  CA_MarkGrChunk(SNAKETALKPIC);
+  CA_MarkGrChunk(HOSTAGE1_PIC);
+  CA_MarkGrChunk(HOSTAGE2_PIC);
+  CA_MarkGrChunk(HOSTAGE3_PIC);
+  CA_MarkGrChunk(SNAKETALK_PIC);
   CA_CacheMarks(0);
 
   VW_FixRefreshBuffer();
@@ -765,24 +765,24 @@ void HostageDialog(void)
 
     switch (i)
     {
-      case  0: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE1PIC); break;
-      case  1: VWB_DrawPic(WindowX, WindowY+4, SNAKETALKPIC); break;
-      case  2: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE3PIC); break;
-      case  3: VWB_DrawPic(WindowX, WindowY+4, SNAKETALKPIC); break;
-      case  4: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE2PIC); break;
-      case  5: VWB_DrawPic(WindowX, WindowY+4, SNAKETALKPIC); break;
-      case  6: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE1PIC); break;
-      case  7: VWB_DrawPic(WindowX, WindowY+4, SNAKETALKPIC); break;
-      case  8: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE3PIC); break;
-      case  9: VWB_DrawPic(WindowX, WindowY+4, SNAKETALKPIC); break;
-      case 10: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE2PIC); break;
-      case 11: VWB_DrawPic(WindowX, WindowY+4, SNAKETALKPIC); break;
-      case 12: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE1PIC); break;
-      case 13: VWB_DrawPic(WindowX, WindowY+4, SNAKETALKPIC); break;
-      case 14: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE2PIC); break;
-      case 15: VWB_DrawPic(WindowX, WindowY+4, SNAKETALKPIC); break;
-      case 16: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE2PIC); break;
-      case 17: VWB_DrawPic(WindowX, WindowY+4, SNAKETALKPIC); break;
+      case  0: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE1_PIC); break;
+      case  1: VWB_DrawPic(WindowX, WindowY+4, SNAKETALK_PIC); break;
+      case  2: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE3_PIC); break;
+      case  3: VWB_DrawPic(WindowX, WindowY+4, SNAKETALK_PIC); break;
+      case  4: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE2_PIC); break;
+      case  5: VWB_DrawPic(WindowX, WindowY+4, SNAKETALK_PIC); break;
+      case  6: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE1_PIC); break;
+      case  7: VWB_DrawPic(WindowX, WindowY+4, SNAKETALK_PIC); break;
+      case  8: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE3_PIC); break;
+      case  9: VWB_DrawPic(WindowX, WindowY+4, SNAKETALK_PIC); break;
+      case 10: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE2_PIC); break;
+      case 11: VWB_DrawPic(WindowX, WindowY+4, SNAKETALK_PIC); break;
+      case 12: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE1_PIC); break;
+      case 13: VWB_DrawPic(WindowX, WindowY+4, SNAKETALK_PIC); break;
+      case 14: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE2_PIC); break;
+      case 15: VWB_DrawPic(WindowX, WindowY+4, SNAKETALK_PIC); break;
+      case 16: VWB_DrawPic(WindowX, WindowY+4, HOSTAGE2_PIC); break;
+      case 17: VWB_DrawPic(WindowX, WindowY+4, SNAKETALK_PIC); break;
     }
 
     PrintY += 6;

--- a/SRC/BM_TEXT.C
+++ b/SRC/BM_TEXT.C
@@ -481,7 +481,7 @@ static void DrawNagScreenTimer(void)
   Sint16 oldcolor;
   oldcolor = fontcolor;
 
-  VWB_DrawPic(16, 176, H_BOTTOMINFOPIC);
+  VWB_DrawPic(16, 176, H_BOTTOMINFO_PIC);
 
   strcpy(str, "Timer= ");
 
@@ -532,16 +532,16 @@ void PageLayout(boolean shownumber)
 // clear the screen
 //
   VWB_Bar(0, 0, 320, 200, BACKCOLOR);
-  VWB_DrawPic( 16, 0, H_TOPWINDOWPIC);
-  VWB_DrawPic(  0, 0, H_LEFTWINDOWPIC);
-  VWB_DrawPic(304, 0, H_RIGHTWINDOWPIC);
+  VWB_DrawPic( 16, 0, H_TOPWINDOW_PIC);
+  VWB_DrawPic(  0, 0, H_LEFTWINDOW_PIC);
+  VWB_DrawPic(304, 0, H_RIGHTWINDOW_PIC);
   if (shownumber)
   {
-    VWB_DrawPic(16, 176, H_BOTTOMINFOPIC);
+    VWB_DrawPic(16, 176, H_BOTTOMINFO_PIC);
   }
   else
   {
-    VWB_DrawPic(16, 192, H_TOPWINDOWPIC);
+    VWB_DrawPic(16, 192, H_TOPWINDOW_PIC);
   }
 
   for (i=0; i<TEXTROWS; i++)
@@ -655,10 +655,10 @@ void CacheLayoutGraphics(void)
   bombpoint = text+30000;
   numpages = pagenum = 0;
 
-  CA_MarkGrChunk(H_TOPWINDOWPIC);
-  CA_MarkGrChunk(H_LEFTWINDOWPIC);
-  CA_MarkGrChunk(H_RIGHTWINDOWPIC);
-  CA_MarkGrChunk(H_BOTTOMINFOPIC);
+  CA_MarkGrChunk(H_TOPWINDOW_PIC);
+  CA_MarkGrChunk(H_LEFTWINDOW_PIC);
+  CA_MarkGrChunk(H_RIGHTWINDOW_PIC);
+  CA_MarkGrChunk(H_BOTTOMINFO_PIC);
 
   do
   {
@@ -714,17 +714,17 @@ Sint16 HelpMenu(void)
 
   VWB_Bar(0, 0, 320, 200, BACKCOLOR);
 
-  CA_CacheGrChunk(H_HELPPIC);
-  CA_CacheGrChunk(H_HANDPIC);
-  CA_CacheGrChunk(H_TOPWINDOWPIC);
-  CA_CacheGrChunk(H_LEFTWINDOWPIC);
-  CA_CacheGrChunk(H_RIGHTWINDOWPIC);
+  CA_CacheGrChunk(H_HELP_PIC);
+  CA_CacheGrChunk(H_HAND_PIC);
+  CA_CacheGrChunk(H_TOPWINDOW_PIC);
+  CA_CacheGrChunk(H_LEFTWINDOW_PIC);
+  CA_CacheGrChunk(H_RIGHTWINDOW_PIC);
 
-  VWB_DrawPic( 16,   0, H_TOPWINDOWPIC);
-  VWB_DrawPic(  0,   0, H_LEFTWINDOWPIC);
-  VWB_DrawPic(304,   0, H_RIGHTWINDOWPIC);
-  VWB_DrawPic( 16, 192, H_TOPWINDOWPIC);
-  VWB_DrawPic( 88,   8, H_HELPPIC);
+  VWB_DrawPic( 16,   0, H_TOPWINDOW_PIC);
+  VWB_DrawPic(  0,   0, H_LEFTWINDOW_PIC);
+  VWB_DrawPic(304,   0, H_RIGHTWINDOW_PIC);
+  VWB_DrawPic( 16, 192, H_TOPWINDOW_PIC);
+  VWB_DrawPic( 88,   8, H_HELP_PIC);
 
   ydelta = 0;
   IN_ClearKeysDown();
@@ -738,7 +738,7 @@ Sint16 HelpMenu(void)
     {
       myhelpmenupos = 4;
     }
-    VWB_DrawPic(56, 24*myhelpmenupos+56, H_HANDPIC);
+    VWB_DrawPic(56, 24*myhelpmenupos+56, H_HAND_PIC);
     VW_UpdateScreen();
     VWB_Bar(56, 24*myhelpmenupos+56, 31, 24, BACKCOLOR);
     IN_ReadControl(0, &control);
@@ -998,8 +998,8 @@ void EpisodeEndScreens(void)
   RF_FixOfs();
   CA_UpLevel();
   CA_SetGrPurge();
-  CA_CacheGrChunk(H_FLASHARROW2PIC);
-  CA_CacheGrChunk(H_FLASHARROW1PIC);
+  CA_CacheGrChunk(H_FLASHARROW2_PIC);
+  CA_CacheGrChunk(H_FLASHARROW1_PIC);
 
   CA_CacheGrChunk(T_ENDART);
   textseg = grsegs[T_ENDART];
@@ -1017,7 +1017,7 @@ void EpisodeEndScreens(void)
 
     do
     {
-      VWB_DrawPic(298, 184, H_FLASHARROW1PIC);
+      VWB_DrawPic(298, 184, H_FLASHARROW1_PIC);
       for (i=0; i<TickBase; i++)
       {
         if (IN_IsUserInput())
@@ -1027,7 +1027,7 @@ void EpisodeEndScreens(void)
         VW_WaitVBL(1);
       }
 
-      VWB_DrawPic(298, 184, H_FLASHARROW2PIC);
+      VWB_DrawPic(298, 184, H_FLASHARROW2_PIC);
       for (i=0; i<TickBase; i++)
       {
         if (IN_IsUserInput())
@@ -1045,8 +1045,8 @@ nextpage:
   StopMusic();
 
   MM_FreePtr(&grsegs[T_ENDART]);
-  MM_FreePtr(&grsegs[H_FLASHARROW1PIC]);
-  MM_FreePtr(&grsegs[H_FLASHARROW2PIC]);
+  MM_FreePtr(&grsegs[H_FLASHARROW1_PIC]);
+  MM_FreePtr(&grsegs[H_FLASHARROW2_PIC]);
   CA_DownLevel();
   IN_ClearKeysDown();
   VW_ClearVideo(BACKCOLOR);

--- a/SRC/GRAPHBM1.H
+++ b/SRC/GRAPHBM1.H
@@ -83,66 +83,66 @@ typedef enum {
   //
 
   START_LUMP(CONTROLS_LUMP_START, __CONTROLSSTART)
-  CP_MAINMENUPIC,              // 5
-  CP_NEWGAMEMENUPIC,           // 6
-  CP_LOADMENUPIC,              // 7
-  CP_SAVEMENUPIC,              // 8
-  CP_CONFIGMENUPIC,            // 9
-  CP_SOUNDMENUPIC,             // 10
-  CP_MUSICMENUPIC,             // 11
-  CP_KEYBOARDMENUPIC,          // 12
-  CP_KEYMOVEMENTPIC,           // 13
-  CP_KEYBUTTONPIC,             // 14
-  CP_JOYSTICKMENUPIC,          // 15
-  CP_OPTIONSMENUPIC,           // 16
-  CP_QUITPIC,                  // 17
-  CP_JOYSTICKPIC,              // 18
-  CP_MENUSCREENPIC,            // 19
+  CP_MAINMENU_PIC,             // 5
+  CP_NEWGAMEMENU_PIC,          // 6
+  CP_LOADMENU_PIC,             // 7
+  CP_SAVEMENU_PIC,             // 8
+  CP_CONFIGMENU_PIC,           // 9
+  CP_SOUNDMENU_PIC,            // 10
+  CP_MUSICMENU_PIC,            // 11
+  CP_KEYBOARDMENU_PIC,         // 12
+  CP_KEYMOVEMENT_PIC,          // 13
+  CP_KEYBUTTON_PIC,            // 14
+  CP_JOYSTICKMENU_PIC,         // 15
+  CP_OPTIONSMENU_PIC,          // 16
+  CP_QUIT_PIC,                 // 17
+  CP_JOYSTICK_PIC,             // 18
+  CP_MENUSCREEN_PIC,           // 19
   END_LUMP(CONTROLS_LUMP_END, __CONTROLSEND)
 
-  TITLESHAREWAREPIC,           // 20
-  H_HELPPIC,                   // 21
-  H_HANDPIC,                   // 22
-  H_FLASHARROW1PIC,            // 23
-  H_FLASHARROW2PIC,            // 24
-  H_TOPWINDOWPIC,              // 25
-  H_LEFTWINDOWPIC,             // 26
-  H_RIGHTWINDOWPIC,            // 27
-  H_BOTTOMINFOPIC,             // 28
-  H_ESCPIC,                    // 29
-  H_LARROWPIC,                 // 30
-  H_RARROWPIC,                 // 31
-  H_ENTERPIC,                  // 32
-  ENDOFTEXTPIC,                // 33
-  H_VISAPIC,                   // 34
-  H_MCPIC,                     // 35
-  HOSTAGE1PIC,                 // 36
-  HOSTAGE2PIC,                 // 37
-  HOSTAGE3PIC,                 // 38
-  SNAKETALKPIC,                // 39
-  H_ITEMSPIC,                  // 40
-  STORY1PIC,                   // 41
-  STORY2PIC,                   // 42
-  STORY3PIC,                   // 43
-  STORY4PIC,                   // 44
-  STORY5PIC,                   // 45
-  STORY6PIC,                   // 46
-  STORY7PIC,                   // 47
-  STORY8PIC,                   // 48
-  STORY9PIC,                   // 49
-  CREDITSPIC,                  // 50
-  PREVIEWPIC,                  // 51
-  TITLEPIC,                    // 52
-  NOTSHAREWAREPIC,             // 53
-  TECHHELPPIC,                 // 54
+  TITLESHAREWARE_PIC,          // 20
+  H_HELP_PIC,                  // 21
+  H_HAND_PIC,                  // 22
+  H_FLASHARROW1_PIC,           // 23
+  H_FLASHARROW2_PIC,           // 24
+  H_TOPWINDOW_PIC,             // 25
+  H_LEFTWINDOW_PIC,            // 26
+  H_RIGHTWINDOW_PIC,           // 27
+  H_BOTTOMINFO_PIC,            // 28
+  H_ESC_PIC,                   // 29
+  H_LARROW_PIC,                // 30
+  H_RARROW_PIC,                // 31
+  H_ENTER_PIC,                 // 32
+  ENDOFTEXT_PIC,               // 33
+  H_VISA_PIC,                  // 34
+  H_MC_PIC,                    // 35
+  HOSTAGE1_PIC,                // 36
+  HOSTAGE2_PIC,                // 37
+  HOSTAGE3_PIC,                // 38
+  SNAKETALK_PIC,               // 39
+  H_ITEMS_PIC,                 // 40
+  STORY1_PIC,                  // 41
+  STORY2_PIC,                  // 42
+  STORY3_PIC,                  // 43
+  STORY4_PIC,                  // 44
+  STORY5_PIC,                  // 45
+  STORY6_PIC,                  // 46
+  STORY7_PIC,                  // 47
+  STORY8_PIC,                  // 48
+  STORY9_PIC,                  // 49
+  CREDITS_PIC,                 // 50
+  PREVIEW_PIC,                 // 51
+  TITLE_PIC,                   // 52
+  NOTSHAREWARE_PIC,            // 53
+  TECHHELP_PIC,                // 54
 
-  CP_MENUMASKPICM,             // 55
+  CP_MENUMASK_PICM,            // 55
 
   //
   // SPRITES
   //
 
-  HANDCURSORSPR,               // 56
+  HANDCURSOR_SPR,              // 56
 
   START_LUMP(PLAYER_LUMP_START, __PLAYERSTART)
   SHOT_EXPLODE1_SPR,           // 57
@@ -352,24 +352,24 @@ typedef enum {
   END_LUMP(BRAWLER_LUMP_END, __BRAWLEREND)
 
   START_LUMP(CEILWALKER_LUMP_START, __CEILWALKERSTART)
-  CEILWALKER_WALK_CEIL1_L,     // 249
-  CEILWALKER_WALK_CEIL2_L,     // 250
-  CEILWALKER_WALK_CEIL3_L,     // 251
-  CEILWALKER_WALK_CEIL4_L,     // 252
-  CEILWALKER_FALL_L,           // 253
-  CEILWALKER_WALK_CEIL1_R,     // 254
-  CEILWALKER_WALK_CEIL2_R,     // 255
-  CEILWALKER_WALK_CEIL3_R,     // 256
-  CEILWALKER_WALK_CEIL4_R,     // 257
-  CEILWALKER_FALL_R,           // 258
-  CEILWALKER_WALK1_L,          // 259
-  CEILWALKER_WALK2_L,          // 260
-  CEILWALKER_WALK3_L,          // 261
-  CEILWALKER_WALK4_L,          // 262
-  CEILWALKER_WALK1_R,          // 263
-  CEILWALKER_WALK2_R,          // 264
-  CEILWALKER_WALK3_R,          // 265
-  CEILWALKER_WALK4_R,          // 266
+  CEILWALKER_WALK_CEIL1_L_SPR, // 249
+  CEILWALKER_WALK_CEIL2_L_SPR, // 250
+  CEILWALKER_WALK_CEIL3_L_SPR, // 251
+  CEILWALKER_WALK_CEIL4_L_SPR, // 252
+  CEILWALKER_FALL_L_SPR,       // 253
+  CEILWALKER_WALK_CEIL1_R_SPR, // 254
+  CEILWALKER_WALK_CEIL2_R_SPR, // 255
+  CEILWALKER_WALK_CEIL3_R_SPR, // 256
+  CEILWALKER_WALK_CEIL4_R_SPR, // 257
+  CEILWALKER_FALL_R_SPR,       // 258
+  CEILWALKER_WALK1_L_SPR,      // 259
+  CEILWALKER_WALK2_L_SPR,      // 260
+  CEILWALKER_WALK3_L_SPR,      // 261
+  CEILWALKER_WALK4_L_SPR,      // 262
+  CEILWALKER_WALK1_R_SPR,      // 263
+  CEILWALKER_WALK2_R_SPR,      // 264
+  CEILWALKER_WALK3_R_SPR,      // 265
+  CEILWALKER_WALK4_R_SPR,      // 266
   END_LUMP(CEILWALKER_LUMP_END, __CEILWALKEREND)
 
   START_LUMP(BOMB_LUMP_START, __BOMBSTART)
@@ -517,7 +517,7 @@ typedef enum {
   END_LUMP(BOUNCEBOT_LUMP_END, __BOUNCEBOTEND)
 
   START_LUMP(PLATFORM_LUMP_START, __PLATFORMSTART)
-  PLATFORMSPR,                 // 369
+  PLATFORM_SPR,                // 369
   END_LUMP(PLATFORM_LUMP_END, __PLATFORMEND)
 
   START_LUMP(UNUSED3_LUMP_START, __UNUSED3START)
@@ -552,7 +552,7 @@ typedef enum {
   END_LUMP(SPARKSHOT_LUMP_END, __SPARKSHOTEND)
 
   START_LUMP(PUSHBLOCK_LUMP_START, __PUSHBLOCKSTART)
-  PUSHBLOCKSPR,                // 386
+  PUSHBLOCK_SPR,               // 386
   END_LUMP(PUSHBLOCK_LUMP_END, __PUSHBLOCKEND)
 
   START_LUMP(ROBOPAL_LUMP_START, __ROBOPALSTART)
@@ -569,11 +569,11 @@ typedef enum {
   END_LUMP(ROBOPAL_LUMP_END, __ROBOPALEND)
 
   START_LUMP(CRUSHERBLOCK_LUMP_START, __CRUSHERBLOCKSTART)
-  CRUSHERBLOCKSPR,             // 397
+  CRUSHERBLOCK_SPR,            // 397
   END_LUMP(CRUSHERBLOCK_LUMP_END, __CRUSHERBLOCKEND)
 
   START_LUMP(FALLINGBLOCK_LUMP_START, __FALLINGBLOCKSTART)
-  FALLINGBLOCKSPR,             // 398
+  FALLINGBLOCK_SPR,            // 398
   END_LUMP(FALLINGBLOCK_LUMP_END, __FALLINGBLOCKEND)
 
   START_LUMP(TANKBOT_LUMP_START, __TANKBOTSTART)
@@ -585,10 +585,10 @@ typedef enum {
   TANKBOT_SHOT_LANDING_SPR,    // 404
   END_LUMP(TANKBOT_LUMP_END, __TANKBOTEND)
 
-  SCOREBOXSPR,                 // 405
+  SCOREBOX_SPR,                // 405
 
   START_LUMP(INTRO_LUMP_START, __INTROSTART)
-  APOGEELOGOSPR,               // 406
+  APOGEELOGO_SPR,              // 406
   ASTEROID1_SPR,               // 407
   ASTEROID2_SPR,               // 408
   ASTEROID3_SPR,               // 409

--- a/SRC/ID_US_2.C
+++ b/SRC/ID_US_2.C
@@ -172,7 +172,7 @@ static  boolean USL_ConfigCustom(UserCall call,struct UserItem far *item),
     {DefButton(sc_None,"DEBUG")},
     {uii_Bad}
   };
-  UserItemGroup   far holdergroup = {0,0,CP_MAINMENUPIC,sc_None,holder};
+  UserItemGroup   far holdergroup = {0,0,CP_MAINMENU_PIC,sc_None,holder};
 
   // Sound menu
   UserItem far soundi[] =
@@ -183,7 +183,7 @@ static  boolean USL_ConfigCustom(UserCall call,struct UserItem far *item),
     {DefRButton(sc_Q,"QUIET ADLIB/SOUNDBLASTER")},
     {uii_Bad}
   };
-  UserItemGroup   far soundgroup = {8,0,CP_SOUNDMENUPIC,sc_None,soundi};
+  UserItemGroup   far soundgroup = {8,0,CP_SOUNDMENU_PIC,sc_None,soundi};
 
   // Music menu
   UserItem far musici[] =
@@ -192,7 +192,7 @@ static  boolean USL_ConfigCustom(UserCall call,struct UserItem far *item),
     {DefRButton(sc_A,"ADLIB/SOUNDBLASTER")},
     {uii_Bad}
   };
-  UserItemGroup   far musicgroup = {8,0,CP_MUSICMENUPIC,sc_None,musici};
+  UserItemGroup   far musicgroup = {8,0,CP_MUSICMENU_PIC,sc_None,musici};
 
   // New game menu
   UserItem far newgamei[] =
@@ -203,7 +203,7 @@ static  boolean USL_ConfigCustom(UserCall call,struct UserItem far *item),
     {DefButton(sc_P,"PRACTICE A LEVEL (15 sec)"),uc_SPractice},
     {uii_Bad}
   };
-  UserItemGroup   far newgamegroup = {8,0,CP_NEWGAMEMENUPIC,sc_None,newgamei,0,1};
+  UserItemGroup   far newgamegroup = {8,0,CP_NEWGAMEMENU_PIC,sc_None,newgamei,0,1};
 
   // Load/Save game menu
   UserItem far loadsavegamei[] =
@@ -216,8 +216,8 @@ static  boolean USL_ConfigCustom(UserCall call,struct UserItem far *item),
     {uii_Button,ui_Normal,sc_6},
     {uii_Bad}
   };
-  UserItemGroup   far loadgamegroup = {4,3,CP_LOADMENUPIC,sc_None,loadsavegamei,USL_LoadCustom};
-  UserItemGroup   far savegamegroup = {4,3,CP_SAVEMENUPIC,sc_None,loadsavegamei,USL_SaveCustom};
+  UserItemGroup   far loadgamegroup = {4,3,CP_LOADMENU_PIC,sc_None,loadsavegamei,USL_LoadCustom};
+  UserItemGroup   far savegamegroup = {4,3,CP_SAVEMENU_PIC,sc_None,loadsavegamei,USL_SaveCustom};
 
   // Options menu
   UserItemGroup   far compgroup = {0,0,0,sc_None,0,USL_CompCustom};
@@ -231,7 +231,7 @@ static  boolean USL_ConfigCustom(UserCall call,struct UserItem far *item),
     {DefFolder(sc_H,"",&helpgroup)},
     {uii_Bad}
   };
-  UserItemGroup   far optionsgroup = {8,0,CP_OPTIONSMENUPIC,sc_None,optionsi};
+  UserItemGroup   far optionsgroup = {8,0,CP_OPTIONSMENU_PIC,sc_None,optionsi};
 
   // Keyboard menu
   UserItem far keyi[] =
@@ -246,7 +246,7 @@ static  boolean USL_ConfigCustom(UserCall call,struct UserItem far *item),
     {DefButton(sc_None,"LEFT")},
     {uii_Bad}
   };
-  UserItemGroup   far keygroup = {0,0,CP_KEYMOVEMENTPIC,sc_None,keyi,USL_KeyCustom};
+  UserItemGroup   far keygroup = {0,0,CP_KEYMOVEMENT_PIC,sc_None,keyi,USL_KeyCustom};
   UserItem far keybi[] =
   {
     {DefButton(sc_J,"JUMP")},
@@ -254,18 +254,18 @@ static  boolean USL_ConfigCustom(UserCall call,struct UserItem far *item),
     {DefButton(sc_G,"GRENADE")},
     {uii_Bad}
   };
-  UserItemGroup   far keybgroup = {0,0,CP_KEYBUTTONPIC,sc_None,keybi,USL_KeyCustom};
+  UserItemGroup   far keybgroup = {0,0,CP_KEYBUTTON_PIC,sc_None,keybi,USL_KeyCustom};
   UserItem far keysi[] =
   {
     {DefFolder(sc_M,"MOVEMENT",&keygroup)},
     {DefFolder(sc_B,"BUTTONS",&keybgroup)},
     {uii_Bad}
   };
-  UserItemGroup   far keysgroup = {8,0,CP_KEYBOARDMENUPIC,sc_None,keysi,USL_KeySCustom};
+  UserItemGroup   far keysgroup = {8,0,CP_KEYBOARDMENU_PIC,sc_None,keysi,USL_KeySCustom};
 
   // Joystick #1 & #2
-  UserItemGroup   far joy1group = {CustomGroup(CP_JOYSTICKMENUPIC,sc_None,USL_Joy1Custom)};
-  UserItemGroup   far joy2group = {CustomGroup(CP_JOYSTICKMENUPIC,sc_None,USL_Joy2Custom)};
+  UserItemGroup   far joy1group = {CustomGroup(CP_JOYSTICKMENU_PIC,sc_None,USL_Joy1Custom)};
+  UserItemGroup   far joy2group = {CustomGroup(CP_JOYSTICKMENU_PIC,sc_None,USL_Joy2Custom)};
 
   // Config menu
   UserItem far configi[] =
@@ -278,7 +278,7 @@ static  boolean USL_ConfigCustom(UserCall call,struct UserItem far *item),
     {DefFolder(sc_2,"USE JOYSTICK #2",&joy2group)},
     {uii_Bad}
   };
-  UserItemGroup   far configgroup = {8,0,CP_CONFIGMENUPIC,sc_None,configi,USL_ConfigCustom};
+  UserItemGroup   far configgroup = {8,0,CP_CONFIGMENU_PIC,sc_None,configi,USL_ConfigCustom};
 
   // Main menu
   UserItem far rooti[] =
@@ -292,7 +292,7 @@ static  boolean USL_ConfigCustom(UserCall call,struct UserItem far *item),
     {DefButton(sc_Q,"QUIT"),uc_Quit},
     {uii_Bad}
   };
-  UserItemGroup   far rootgroup = {32,4,CP_MAINMENUPIC,sc_None,rooti};
+  UserItemGroup   far rootgroup = {32,4,CP_MAINMENU_PIC,sc_None,rooti};
 #undef  DefButton
 #undef  DefFolder
 
@@ -456,7 +456,7 @@ USL_DrawCtlPanel(void)
   if (topcard->items || topcard->title)
   {
     // Draw the backdrop
-    VWB_DrawPic(0,0,CP_MENUSCREENPIC);
+    VWB_DrawPic(0,0,CP_MENUSCREEN_PIC);
 
     // Draw the contents
     USL_DrawCtlPanelContents();
@@ -469,7 +469,7 @@ USL_DrawCtlPanel(void)
 static void
 USL_DialogSetup(word w,word h,word *x,word *y)
 {
-  VWB_DrawMPic(CtlPanelSX,CtlPanelSY,CP_MENUMASKPICM);
+  VWB_DrawMPic(CtlPanelSX,CtlPanelSY,CP_MENUMASK_PICM);
 
   *x = CtlPanelSX + ((CtlPanelW - w) / 2);
   *y = CtlPanelSY + ((CtlPanelH - h) / 2);
@@ -933,7 +933,7 @@ USL_ConfigJoystick(word joy)
   USL_DrawCtlPanel();
   x = CtlPanelSX + 60;
   y = CtlPanelSY + 19;
-  VWB_DrawPic(x,y,CP_JOYSTICKPIC);
+  VWB_DrawPic(x,y,CP_JOYSTICK_PIC);
 
   USL_CJDraw("Move Joystick to upper left","and press button #1");
   VWB_DrawTile8(x + 24,y + 8,TileBase + 6);
@@ -1406,7 +1406,7 @@ USL_SetUpCtlPanel(void)
   for (i = CONTROLS_LUMP_START;i <= CONTROLS_LUMP_END;i++)
     CA_MarkGrChunk(i);
   CA_MarkGrChunk(STARTFONT+1);            // Little font
-  CA_MarkGrChunk(CP_MENUMASKPICM);        // Mask for dialogs
+  CA_MarkGrChunk(CP_MENUMASK_PICM);       // Mask for dialogs
   CA_CacheMarks("Control Panel");
   CA_LoadAllSounds();
 


### PR DESCRIPTION
Bio Menace's graphics were originally imported using a tool called IGRAB, which generates the GRAPHBM1.H and GRAPHBM1.EQU files with the chunk numbers, and other metadata.

IGRAB, however, has a number of rules when generating these names (see FINISH.C):
- Bitmaps have 'PIC' appended to the name.
- Masked bitmaps have 'PICM' appended to the name.
- Sprites have 'SPR' appended to the name.
- (Other chunks have no naming restrictions)

The Bio Menace decomp uses a handwritten GRAPHBM1.{H,EQU} file, as the originals are not available (and neither is the IGRAB .I script). However, the names used do not conform to the original IGRAB rules, so it would not be possible to reconstruct such a file, or to use other tools which expect such formatting, to create compatible headers.

In particular:
- The 'ceilwalker' graphics chunks are missing a 'SPR' suffix.
- Where a 'SPR' suffix is used, it is separated with an underscore, making it '_SPR'. This is not a problem, but does look a bit weird (IGRAB must be given a name with a trailing underscore).

This change mechanically adds 'SPR' as a suffix where it was not present, and removes the '_' from '_SPR' where used. This is still a bit ugly, but it is representable.

I've tested this with headers generated from my own in-progress [idGrab](https://github.com/sulix/idgrab) tool, which can generate IGRAB-style headers, and the game builds and runs fine.

As an example, idGrab can use [this script](https://davidgow.net/stuff/bmenace1.idgrab) to generate:
- [GRAPHBM1.H](https://davidgow.net/stuff/GRAPHBM1.H)
- [GRAPHBM1.EQU](https://davidgow.net/stuff/GRAPHBM1.EQU)


What do you think?
Personally, I'd like to at least give CEILWALKER the SPR ending, but could learn to live with the underscores (I do agree they look nicer in the manually-made headers.)